### PR TITLE
Replace Logback logging with SLF4J in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,7 @@ dependencies {
     api group: 'io.vertx', name: 'vertx-core', version: "${vertxVersion}"
     testImplementation group: 'io.vertx', name: 'vertx-unit', version: "${vertxVersion}"
 
-    // logback
-    api group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.8'
-    api group: 'ch.qos.logback', name: 'logback-core', version: '1.4.8'
+    // logging
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
 
     api group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'


### PR DESCRIPTION
Removed the dependency on the Logback logging library in the build.gradle file and replaced it with SLF4J. This change was made to standardize the logging framework across all modules and to improve compatibility across different environments.